### PR TITLE
Sso bypass

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ HTTP-protected resources; if not, you could remove the module for good
 by replacing the following 2 lines:
 
 import http_auth
-url_opener = http_auth.ProxyAuthURLopener()
+url_opener = http_auth.ProtectedURLopener()
 
 by
 

--- a/spellchecker
+++ b/spellchecker
@@ -19,6 +19,7 @@ import http_auth
 import os
 import sys
 import urllib.parse
+import urllib.error
 
 from cleanhtml import *
 from subprocess import Popen, PIPE
@@ -181,8 +182,11 @@ if __name__ == '__main__':
     try:
         uri = escapeURLQueryString(uri)
         fp = url_opener.open(uri)
-    except IOError as e:
-        url_opener.error = "I/O error: %s %s" % (e.errno,e.strerror)
+    except urllib.error.HTTPError as error:
+        url_opener.error = f"HTTP Error: {error.code} {error.reason}"
+        fp = None
+    except OSError as e:
+        url_opener.error = f"I/O error: {error.errno} {error.strerr}"
         fp = None
     if fp is None:
         clean_print("<p><span class='no'>Unable to read</span> <a href='%s'>%s</a> (%s). Sorry, check the URI.</p>", uri, uri, url_opener.error)

--- a/spellchecker
+++ b/spellchecker
@@ -188,9 +188,13 @@ if __name__ == '__main__':
     except urllib.error.URLError as error:
         url_opener.error = f"URL error: {str(error.reason)}"
         fp = None
-    except OSError as e:
+    except ValueError as error:
+        url_opener.error = f"URL error: {str(error)}"
+        fp = None
+    except OSError as error:
         url_opener.error = f"I/O error: {error.errno} {error.strerr}"
         fp = None
+
     if fp is None:
         clean_print("<p><span class='no'>Unable to read</span> <a href='%s'>%s</a> (%s). Sorry, check the URI.</p>", uri, uri, url_opener.error)
         print(Page2)

--- a/spellchecker
+++ b/spellchecker
@@ -23,7 +23,6 @@ import urllib.error
 
 from cleanhtml import *
 from subprocess import Popen, PIPE
-from email.message import EmailMessage
 
 languages = {"en_US":"English","fr":"French"}
 
@@ -205,12 +204,11 @@ if __name__ == '__main__':
 
     lynx_cmd = ['/usr/bin/lynx', '-cfg=/usr/local/lib/lynx.cfg', '-nolist',
                 '-dump', '-stdin']
+
     if 'Content-Type' in headers:
-        msg = EmailMessage()
-        msg['content-type'] = headers["Content-Type"]
-        if 'charset' in msg['content-type'].params:
-            lynx_cmd.append('-assume_charset=%s' %
-                            msg['content-type'].params['charset'].lower())
+        charset = headers.get_content_charset()
+        if charset:
+            lynx_cmd.append('-assume_charset={}'.format(charset.lower()))
 
     lynx_proc = Popen(lynx_cmd, stdin=PIPE, stdout=PIPE)
 

--- a/spellchecker
+++ b/spellchecker
@@ -28,12 +28,12 @@ from email.message import EmailMessage
 languages = {"en_US":"English","fr":"French"}
 
 def format_option(a,b,c):
-	if a:
-		selected=""
-		if a==c:
-			selected=" selected='selected'"
-		return clean_format("<option value='%s'%s>%s</option>",
-				    a, selected, b)
+    if a:
+        selected=""
+        if a==c:
+            selected=" selected='selected'"
+        return clean_format("<option value='%s'%s>%s</option>",
+                            a, selected, b)
 
 Page1 ="""Content-Type:text/html; charset=utf-8
 
@@ -92,125 +92,125 @@ Last Modified: $Date$
 """
 
 def format(fp,suggest):
-	words = {}
-	for line in fp:
-		line = line.decode("utf-8").rstrip('\n')
-		if line and line != "*" and line[0] != "@":
-			parts = line.split(': ')
-			fields = parts[0].split()
-			if fields[1] in words:
-				continue
-			elif fields[0]=="&":
-				words[fields[1]] = parts[1].split(", ")
-			elif fields[0]=="#":
-				words[fields[1]] = []
-	if not words:
-		print("<p><span class='yes'>No errors</span> found.</p>")
-		return
-	print("<ol>")
-	for error in sorted(words):
-		clean_print("<li>\"<span class='no'>%s</span>\"", error)
-		if words[error] and suggest:
-			print("; suggestions:<ul class='suggestions'>")
-			for option in words[error]:
-				clean_print("<li>%s</li>", option)
-			print("</ul>")
-		print("</li>")
-	print("</ol>")
+    words = {}
+    for line in fp:
+        line = line.decode("utf-8").rstrip('\n')
+        if line and line != "*" and line[0] != "@":
+            parts = line.split(': ')
+            fields = parts[0].split()
+            if fields[1] in words:
+                continue
+            elif fields[0]=="&":
+                words[fields[1]] = parts[1].split(", ")
+            elif fields[0]=="#":
+                words[fields[1]] = []
+    if not words:
+        print("<p><span class='yes'>No errors</span> found.</p>")
+        return
+    print("<ol>")
+    for error in sorted(words):
+        clean_print("<li>\"<span class='no'>%s</span>\"", error)
+        if words[error] and suggest:
+            print("; suggestions:<ul class='suggestions'>")
+            for option in words[error]:
+                clean_print("<li>%s</li>", option)
+            print("</ul>")
+        print("</li>")
+    print("</ol>")
 
 def _getfirst(fields, key, default=None):
-	""" Return the first value received."""
-	if key in fields:
-		return fields[key]
-	else:
-		return default
+    """ Return the first value received."""
+    if key in fields:
+        return fields[key]
+    else:
+        return default
 
 def getLangSetup(fields):
-	lang = _getfirst(fields, 'lang')
-	if lang not in languages:
-		lang = 'en_US'
-	lang_opts = ''.join(format_option(code, languages[code], lang)
-			    for code in languages)
-	return lang, lang_opts
+    lang = _getfirst(fields, 'lang')
+    if lang not in languages:
+        lang = 'en_US'
+    lang_opts = ''.join(format_option(code, languages[code], lang)
+                        for code in languages)
+    return lang, lang_opts
 
 def getSuggestSetup(fields):
-	if _getfirst(fields, 'suggest') == 'on':
-		return True, " checked='checked'"
-	return False, ""
+    if _getfirst(fields, 'suggest') == 'on':
+        return True, " checked='checked'"
+    return False, ""
 
 def getURI(fields):
-	uri = _getfirst(fields, 'uri')
-	if (not uri) and ('referrer' in fields):
-		uri = os.environ.get('HTTP_REFERER')
-	return uri
+    uri = _getfirst(fields, 'uri')
+    if (not uri) and ('referrer' in fields):
+        uri = os.environ.get('HTTP_REFERER')
+    return uri
 
 def escapeURLQueryString(url=None):
-	if url is None:
-		return None
+    if url is None:
+        return None
 
-	url_split = urllib.parse.urlsplit(url)
+    url_split = urllib.parse.urlsplit(url)
 
-	if url_split.query:
-		fields = dict(urllib.parse.parse_qsl(url_split.query))
-		escaped_qs = urllib.parse.urlencode(fields)
-		url_split = url_split._replace(query=escaped_qs)
-		rv = urllib.parse.urlunsplit(url_split)
-	else:
-		rv = url
+    if url_split.query:
+        fields = dict(urllib.parse.parse_qsl(url_split.query))
+        escaped_qs = urllib.parse.urlencode(fields)
+        url_split = url_split._replace(query=escaped_qs)
+        rv = urllib.parse.urlunsplit(url_split)
+    else:
+        rv = url
 
-	return rv
+    return rv
 
 if __name__ == '__main__':
-	fields = dict(urllib.parse.parse_qsl(os.getenv('QUERY_STRING', [])))
-	lang, languages_options = getLangSetup(fields)
-	suggest, suggest_txt = getSuggestSetup(fields)
-	uri = getURI(fields)
-	if not uri:
-		print(Page1 % ('', '', '', clean_str(uri), languages_options,
-			       suggest_txt))
-		print(Page2)
-		sys.exit()
+    fields = dict(urllib.parse.parse_qsl(os.getenv('QUERY_STRING', [])))
+    lang, languages_options = getLangSetup(fields)
+    suggest, suggest_txt = getSuggestSetup(fields)
+    uri = getURI(fields)
+    if not uri:
+        print(Page1 % ('', '', '', clean_str(uri), languages_options,
+                       suggest_txt))
+        print(Page2)
+        sys.exit()
 
-	uri_text1 = clean_format("for %s", uri)
-	uri_text = clean_format(" for <a href=\"%s\">%s</a>", uri, uri)
-	print(Page1 % ('<meta name="ROBOTS" content="NOINDEX,NOFOLLOW"/>',
-		       uri_text1, uri_text, clean_str(uri), languages_options,
-		       suggest_txt))
+    uri_text1 = clean_format("for %s", uri)
+    uri_text = clean_format(" for <a href=\"%s\">%s</a>", uri, uri)
+    print(Page1 % ('<meta name="ROBOTS" content="NOINDEX,NOFOLLOW"/>',
+                   uri_text1, uri_text, clean_str(uri), languages_options,
+                   suggest_txt))
 
-	url_opener = http_auth.ProxyAuthURLopener()
-	try:
-		uri = escapeURLQueryString(uri)
-		fp = url_opener.open(uri)
-	except IOError as e:
-		url_opener.error = "I/O error: %s %s" % (e.errno,e.strerror)
-		fp = None
-	if fp is None:
-		clean_print("<p><span class='no'>Unable to read</span> <a href='%s'>%s</a> (%s). Sorry, check the URI.</p>", uri, uri, url_opener.error)
-		print(Page2)
-		sys.exit()
-	headers = fp.info()
-	inp = fp.read()
-	lynx_cmd = ['/usr/bin/lynx', '-cfg=/usr/local/lib/lynx.cfg', '-nolist',
-		    '-dump', '-stdin']
-	if 'Content-Type' in headers:
-		msg = EmailMessage()
-		msg['content-type'] = headers["Content-Type"]
-		if 'charset' in msg['content-type'].params:
-			lynx_cmd.append('-assume_charset=%s' %
-					msg['content-type'].params['charset'].lower())
+    url_opener = http_auth.ProxyAuthURLopener()
+    try:
+        uri = escapeURLQueryString(uri)
+        fp = url_opener.open(uri)
+    except IOError as e:
+        url_opener.error = "I/O error: %s %s" % (e.errno,e.strerror)
+        fp = None
+    if fp is None:
+        clean_print("<p><span class='no'>Unable to read</span> <a href='%s'>%s</a> (%s). Sorry, check the URI.</p>", uri, uri, url_opener.error)
+        print(Page2)
+        sys.exit()
+    headers = fp.info()
+    inp = fp.read()
+    lynx_cmd = ['/usr/bin/lynx', '-cfg=/usr/local/lib/lynx.cfg', '-nolist',
+                '-dump', '-stdin']
+    if 'Content-Type' in headers:
+        msg = EmailMessage()
+        msg['content-type'] = headers["Content-Type"]
+        if 'charset' in msg['content-type'].params:
+            lynx_cmd.append('-assume_charset=%s' %
+                            msg['content-type'].params['charset'].lower())
 
-	lynx_proc = Popen(lynx_cmd, stdin=PIPE, stdout=PIPE)
+    lynx_proc = Popen(lynx_cmd, stdin=PIPE, stdout=PIPE)
 
-	aspell_command = ['/usr/bin/aspell', '-a', '--encoding=utf-8',
-                          '--sug-mode=fast', '--save-repl=false', '--lang', lang]
+    aspell_command = ['/usr/bin/aspell', '-a', '--encoding=utf-8',
+                      '--sug-mode=fast', '--save-repl=false', '--lang', lang]
 
-	aspell_proc = Popen(aspell_command,
-			    stdin=lynx_proc.stdout, stdout=PIPE)
+    aspell_proc = Popen(aspell_command,
+                        stdin=lynx_proc.stdout, stdout=PIPE)
 
-	lynx_proc.communicate(input=inp)
-	lynx_proc.wait()
-	lynx_proc.stdout.close()
-	print("<h2>Errors found in the page</h2>")
-	format(aspell_proc.stdout, suggest)
-	aspell_proc.stdout.close()
-	print(Page2)
+    lynx_proc.communicate(input=inp)
+    lynx_proc.wait()
+    lynx_proc.stdout.close()
+    print("<h2>Errors found in the page</h2>")
+    format(aspell_proc.stdout, suggest)
+    aspell_proc.stdout.close()
+    print(Page2)

--- a/spellchecker
+++ b/spellchecker
@@ -220,12 +220,12 @@ if __name__ == '__main__':
     aspell_proc = Popen(aspell_command,
                         stdin=lynx_proc.stdout, stdout=PIPE)
 
-    lynx_proc.stdout.close()
-
-    lynx_proc.communicate(input=inp)
-    lynx_proc.wait()
+    lynx_proc.stdin.write(inp)
+    lynx_proc.stdin.flush()
+    lynx_proc.stdin.close()
 
     print("<h2>Errors found in the page</h2>")
     format(aspell_proc.stdout.read(), suggest)
     aspell_proc.stdout.close()
+    aspell_proc.wait()
     print(Page2)

--- a/spellchecker
+++ b/spellchecker
@@ -186,7 +186,7 @@ if __name__ == '__main__':
         url_opener.error = f"HTTP Error: {error.code} {error.reason}"
         fp = None
     except urllib.error.URLError as error:
-        opener.error = f"URL error: {str(error.reason)}"
+        url_opener.error = f"URL error: {str(error.reason)}"
         fp = None
     except OSError as e:
         url_opener.error = f"I/O error: {error.errno} {error.strerr}"

--- a/spellchecker
+++ b/spellchecker
@@ -15,7 +15,6 @@ $Id$
  branched from v 1.46
 """
 
-import checkremote
 import http_auth
 import os
 import sys
@@ -93,8 +92,9 @@ Last Modified: $Date$
 
 def format(fp,suggest):
     words = {}
-    for line in fp:
-        line = line.decode("utf-8").rstrip('\n')
+    # convert fp from bytes to string and split into lines
+    for line in fp.decode("utf-8").split('\n'):
+        line = line.rstrip('\n')
         if line and line != "*" and line[0] != "@":
             parts = line.split(': ')
             fields = parts[0].split()
@@ -188,8 +188,10 @@ if __name__ == '__main__':
         clean_print("<p><span class='no'>Unable to read</span> <a href='%s'>%s</a> (%s). Sorry, check the URI.</p>", uri, uri, url_opener.error)
         print(Page2)
         sys.exit()
+
     headers = fp.info()
     inp = fp.read()
+
     lynx_cmd = ['/usr/bin/lynx', '-cfg=/usr/local/lib/lynx.cfg', '-nolist',
                 '-dump', '-stdin']
     if 'Content-Type' in headers:
@@ -207,10 +209,12 @@ if __name__ == '__main__':
     aspell_proc = Popen(aspell_command,
                         stdin=lynx_proc.stdout, stdout=PIPE)
 
+    lynx_proc.stdout.close()
+
     lynx_proc.communicate(input=inp)
     lynx_proc.wait()
-    lynx_proc.stdout.close()
+
     print("<h2>Errors found in the page</h2>")
-    format(aspell_proc.stdout, suggest)
+    format(aspell_proc.stdout.read(), suggest)
     aspell_proc.stdout.close()
     print(Page2)

--- a/spellchecker
+++ b/spellchecker
@@ -192,7 +192,7 @@ if __name__ == '__main__':
         url_opener.error = f"URL error: {str(error)}"
         fp = None
     except OSError as error:
-        url_opener.error = f"I/O error: {error.errno} {error.strerr}"
+        url_opener.error = f"I/O error: {error.errno} {error.strerror}"
         fp = None
 
     if fp is None:

--- a/spellchecker
+++ b/spellchecker
@@ -185,6 +185,9 @@ if __name__ == '__main__':
     except urllib.error.HTTPError as error:
         url_opener.error = f"HTTP Error: {error.code} {error.reason}"
         fp = None
+    except urllib.error.URLError as error:
+        opener.error = f"URL error: {str(error.reason)}"
+        fp = None
     except OSError as e:
         url_opener.error = f"I/O error: {error.errno} {error.strerr}"
         fp = None

--- a/spellchecker
+++ b/spellchecker
@@ -177,7 +177,7 @@ if __name__ == '__main__':
                    uri_text1, uri_text, clean_str(uri), languages_options,
                    suggest_txt))
 
-    url_opener = http_auth.ProxyAuthURLopener()
+    url_opener = http_auth.ProtectedURLopener()
     try:
         uri = escapeURLQueryString(uri)
         fp = url_opener.open(uri)


### PR DESCRIPTION
- Sometimes the pipe from lynx to aspell wasn't working. Fixed by
  replacing pipe.communicate() with an explicit pipe write
- Replaced deprected http_auth.ProxyAuthURLopener class with 
- Added exception handling for HTTPError and URLError and ValueError
- Replace IOError exception with OSError
- Replaced tab identation with 4-spaces per PEP8